### PR TITLE
[2019XXXX] ciの設定を微調整する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
                 cd frontend/support
                 yarn run build
 workflows:
-  version: 2
+  version: 2.1
   go_build:
     jobs:
       - go_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,25 +41,31 @@ jobs:
     steps:
       - checkout
       
-      - run:
-          name: install latest yarn
-          command: |
-              sudo npm uninstall yarn
-              sudo npm install yarn -g
-      
       - restore_cache:
           name: Restore node modules from cache
           keys:
+              - v1-yarn-{{ .Branch }}-{{ checksum "frontend/support/yarn.lock" }}
               - v1-node-{{ .Branch }}-{{ checksum "frontend/support/yarn.lock" }}
-            
+              
       - run:
-          name: install node modules
+          name: Install latest yarn
+          command: |
+              npm uninstall yarn
+              npm install yarn
+              
+      - run:
+          name: Install node modules
           command: |
                 cd frontend/support
                 yarn install
-      
+              
       - save_cache:
-          key: v1-node-{{ .Branch }}-{{ checksum "frontend/support/yarn.lock" }}
+          key: v1-yarn-{{ .Branch }}-{{ checksum "frontend/support/yarn.lock" }}
+          paths:
+              - ~/.cache/yarn
+              
+      - save_cache:
+          key: v1-node-{{ .Branch }}-{{ checksum "frontend/support/package.json" }}
           paths:
               - ~/teixy/frontend/support/node_modules
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,19 @@
-version: 2
-jobs:
-  go_build:
-    working_directory: ~/go/src/github.com/teixy/
-
+executors:
+  go_image:
     docker:
       - image: circleci/golang:1.11.5
         environment:
           GO111MODULE: "on"
+  node_image:
+    docker:
+      - image: circleci/node:10.15.0
+
+version: 2.1
+jobs:
+  go_build:
+    working_directory: ~/go/src/github.com/teixy/
+    
+    executor: go_image
     
     steps:
       - checkout
@@ -35,8 +42,7 @@ jobs:
   support_build:
     working_directory: ~/teixy
     
-    docker:
-      - image: circleci/node:10.15.0
+    executor: node_image
     
     steps:
       - checkout

--- a/frontend/support/vue.Dockerfile
+++ b/frontend/support/vue.Dockerfile
@@ -2,6 +2,7 @@
 FROM node:10.15.0
 WORKDIR /support
 RUN apt-get update && \
+    apt-get upgrade && \
     #vue-cli ver3のinstall
     npm install -g @vue/cli && \
     #yarnを最新にするために入れ直す


### PR DESCRIPTION
# [2019XXXX] ciの設定を微調整する

## 概要
- vue.Dockerfileにapt-get upgradeを追加（ci関係ないけど）
- .circleci/config.yml で executorを使用
- .cache/yarnもキャッシュする


## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



