### PR TITLE
[20190218] ciの設定でyarn cacheをsave cacheするように修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,25 +41,31 @@ jobs:
     steps:
       - checkout
       
-      - run:
-          name: install latest yarn
-          command: |
-              sudo npm uninstall yarn
-              sudo npm install yarn -g
-      
       - restore_cache:
           name: Restore node modules from cache
           keys:
+              - v1-yarn-{{ .Branch }}-{{ checksum "frontend/support/yarn.lock" }}
               - v1-node-{{ .Branch }}-{{ checksum "frontend/support/yarn.lock" }}
-            
+              
       - run:
-          name: install node modules
+          name: Install latest yarn
+          command: |
+              npm uninstall yarn
+              npm install yarn
+              
+      - run:
+          name: Install node modules
           command: |
                 cd frontend/support
                 yarn install
-      
+              
       - save_cache:
-          key: v1-node-{{ .Branch }}-{{ checksum "frontend/support/yarn.lock" }}
+          key: v1-yarn-{{ .Branch }}-{{ checksum "frontend/support/yarn.lock" }}
+          paths:
+              - ~/.cache/yarn
+              
+      - save_cache:
+          key: v1-node-{{ .Branch }}-{{ checksum "frontend/support/package.json" }}
           paths:
               - ~/teixy/frontend/support/node_modules
       

--- a/frontend/support/vue.Dockerfile
+++ b/frontend/support/vue.Dockerfile
@@ -2,6 +2,7 @@
 FROM node:10.15.0
 WORKDIR /support
 RUN apt-get update && \
+    apt-get upgrade && \
     #vue-cli ver3のinstall
     npm install -g @vue/cli && \
     #yarnを最新にするために入れ直す


### PR DESCRIPTION
# [20190218] ciの設定でyarn cacheをsave cacheするように修正

## 概要
- vue.Dockerfileでapt-get upgradeも実行（debianだからね）
- ciで.cache/yarnもキャッシュするように設定
- node_modulesのchacheのkeyを変更


## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



