### PR TITLE
[20190303] controllerのinitでvalidationをnewする

### DIFF
--- a/go/controllers/books.go
+++ b/go/controllers/books.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 )
 
-var validate *validator.Validate
-
 // form validation
 type MinMax struct {
 	Min_Id int `validate:"required,min=1,numeric"`
@@ -54,13 +52,18 @@ type QueryResult struct {
 	RowAffected  int64
 }
 
+var Validate *validator.Validate
+
+func init() {
+	Validate = validator.New()
+}
+
 func GetAllBooks(c echo.Context) error {
 	min_id, _ := strconv.Atoi(c.QueryParam("min_id"))
 	max_id, _ := strconv.Atoi(c.QueryParam("max_id"))
 	params := MinMax{min_id, max_id}
 
-	validate = validator.New()
-	err := validate.Struct(params)
+	err := Validate.Struct(params)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -73,8 +76,7 @@ func GetBook(c echo.Context) error {
 	id, _ := strconv.Atoi(c.Param("id"))
 	params := BookId{id}
 
-	validate = validator.New()
-	err := validate.Struct(params)
+	err := Validate.Struct(params)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -97,8 +99,7 @@ func CreateBook(c echo.Context) error {
 			min_score_value,
 			max_score_value,
 		}
-		validate = validator.New()
-		err := validate.Struct(scores)
+		err := Validate.Struct(scores)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
@@ -113,8 +114,7 @@ func CreateBook(c echo.Context) error {
 		c.FormValue("article"),
 	}
 
-	validate = validator.New()
-	err := validate.Struct(book)
+	err := Validate.Struct(book)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -150,8 +150,7 @@ func UpdateBook(c echo.Context) error {
 			min_score_value,
 			max_score_value,
 		}
-		validate = validator.New()
-		err := validate.Struct(scores)
+		err := Validate.Struct(scores)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
@@ -174,8 +173,7 @@ func UpdateBook(c echo.Context) error {
 		Status{status},
 	}
 
-	validate = validator.New()
-	err := validate.Struct(params)
+	err := Validate.Struct(params)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}


### PR DESCRIPTION
# [20190303] controllerのinitでvalidationをnewする

## 概要
- initでvalidationをnewしてpublicの変数として使う
- 各関数でnewする必要がなくなる


## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



