### PR TITLE
[20190303] go version 1.12を使うように修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/go/src/github.com/teixy/
 
     docker:
-      - image: circleci/golang:1.11.5
+      - image: circleci/golang:1.12
         environment:
           GO111MODULE: "on"
     

--- a/frontend/support/vue.Dockerfile
+++ b/frontend/support/vue.Dockerfile
@@ -2,7 +2,6 @@
 FROM node:10.15.0
 WORKDIR /support
 RUN apt-get update && \
-    apt-get upgrade && \
     #vue-cli ver3のinstall
     npm install -g @vue/cli && \
     #yarnを最新にするために入れ直す

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,6 +1,6 @@
 # go echo api イメージの作成
 # ベースとなるイメージ
-FROM golang:1.11.5
+FROM golang:1.12
 WORKDIR /go/src/github.com/teixy
 ENV GO111MODULE=on
 


### PR DESCRIPTION
# [20190303] go version 1.12を使うように修正

## 概要
- go 1.12を使うように、ci のconfigファイルとgo/Dockerfileを変更


## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



