### PR TITLE
[20190304] isbnカラムをuniqueにする

### DIFF
--- a/migration/sql/201902091742_create_books_table.up.sql
+++ b/migration/sql/201902091742_create_books_table.up.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS `books` (
   `mtime`      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `ctime`      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`book_id`),
+  UNIQUE KEY `isbn` (`isbn`),
   KEY `max_score` (`max_score`),
   KEY `min_score` (`min_score`)
 ) ENGINE=INNODB;


### PR DESCRIPTION
# [20190304] isbnカラムをuniqueにする

## 概要
- isbnをunique keyに設定する
- between book_idで曳くために、isbnはprimaryにはしない


## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



