### PR TITLE
[Test][20190305] firebaseにはciからdeployするようにするためのテスト

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - frontend/support/
+            - .
       
   support_deploy:
     working_directory: ~/teixy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - run:
           name: Deploy project
           command: |
-                ls
+                cd frontend/support
                 firebase deploy --only hosting --project ${FIREBASE_PROJECT} --token ${FIREBASE_TOKEN}
     
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,10 +95,14 @@ jobs:
           at: .
       
       - run:
-          name: 'Install Depencencies'
+          name: Install firebase
           command: |
                 cd frontend/support
                 npm install firebase-tools
+      
+      - run:
+          name: Deploy project
+          command: |
                 firebase deploy --only hosting --project ${FIREBASE_PROJECT} --token ${FIREBASE_TOKEN}
     
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - run:
           name: Install latest yarn
           command: |
-              ls
+              cd frontend/support
               npm uninstall yarn -g
               npm install yarn -g
               

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,16 +52,13 @@ jobs:
       - run:
           name: Install latest yarn
           command: |
-              cd frontend/support
               npm uninstall yarn
               npm install yarn
               
       - run:
           name: Install node modules
           command: |
-                ls
                 cd frontend/support
-                ls
                 yarn install
               
       - save_cache:
@@ -79,15 +76,13 @@ jobs:
       - run:
           name: yarn build
           command: |
-                ls
                 cd frontend/support
-                ls
                 yarn run build
       
       - persist_to_workspace:
           root: .
           paths:
-            - .
+            - frontend/support
       
   support_deploy:
     working_directory: ~/teixy
@@ -101,7 +96,10 @@ jobs:
       
       - run:
           name: 'Install Depencencies'
-          command: ls -l
+          command: |
+                ls -l
+                cd frontend
+                ls -l
     
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,11 +98,12 @@ jobs:
           name: Install firebase
           command: |
                 cd frontend/support
-                npm install firebase-tools
+                npm install --save firebase-tools
       
       - run:
           name: Deploy project
           command: |
+                ls
                 firebase deploy --only hosting --project ${FIREBASE_PROJECT} --token ${FIREBASE_TOKEN}
     
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
     working_directory: ~/teixy
     
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:8.11.3
     
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
     working_directory: ~/teixy
     
     docker:
-      - iamge: circleci/node:8
+      - image: circleci/node:8
     
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
           paths:
             - .
       
-  support_deploy:
+  support_deploy_stg:
     working_directory: ~/teixy
     
     docker:
@@ -104,7 +104,28 @@ jobs:
           name: Deploy project
           command: |
                 cd frontend/support
-                npx firebase deploy --only hosting --project ${FIREBASE_PROJECT_NAME} --token ${FIREBASE_TOKEN}
+                npx firebase deploy --only hosting --project ${FIREBASE_PROJECT_NAME_STG} --token ${FIREBASE_TOKEN_STG}
+                
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+            
+  support_deploy_production:
+    working_directory: ~/teixy
+    
+    docker:
+      - image: circleci/node:8.11.3
+    
+    steps:
+      - attach_workspace:
+          at: .
+      
+      - run:
+          name: Deploy project
+          command: |
+                cd frontend/support
+                npx firebase deploy --only hosting --project ${FIREBASE_PROJECT_NAME} --token ${FIREBASE_TOKEN} 
     
 workflows:
   version: 2
@@ -114,7 +135,16 @@ workflows:
   support:
     jobs:
       - support_build
-      - support_deploy:
+      - support_deploy_stg:
           context: firebase
           requires:
             - support_build
+      - approve_deploy_production:
+          type: approval
+          requires:
+            - support_deploy_stg
+      - support_deploy_production:
+          context: firebase
+          requires:
+            - approve_deploy_production
+            

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
           name: Deploy project
           command: |
                 cd frontend/support
-                npx firebase deploy --only hosting --project ${FIREBASE_PROJECT} --token ${FIREBASE_TOKEN}
+                npx firebase deploy --only hosting --project ${FIREBASE_PROJECT_NAME} --token ${FIREBASE_TOKEN}
     
 workflows:
   version: 2
@@ -115,5 +115,6 @@ workflows:
     jobs:
       - support_build
       - support_deploy:
+          context: firebase
           requires:
             - support_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - frontend/support
+            - frontend/support/
       
   support_deploy:
     working_directory: ~/teixy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
           name: Deploy project
           command: |
                 cd frontend/support
-                firebase deploy --only hosting --project ${FIREBASE_PROJECT} --token ${FIREBASE_TOKEN}
+                npx firebase deploy --only hosting --project ${FIREBASE_PROJECT} --token ${FIREBASE_TOKEN}
     
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
       - run:
           name: Install node modules
           command: |
+                ls
                 cd frontend/support
                 ls
                 yarn install
@@ -77,6 +78,7 @@ jobs:
       - run:
           name: yarn build
           command: |
+                ls
                 cd frontend/support
                 ls
                 yarn run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,34 @@ jobs:
           command: |
                 cd frontend/support
                 yarn run build
+      
+      - persist_to_workspace:
+          root: .
+          paths:
+            - frontend/support
+      
+  support_deploy:
+    working_directory: ~/teixy
+    
+    docker:
+      - iamge: circleci/node:8
+    
+    steps:
+      - attach_workspace:
+          at: .
+      
+      - run:
+          name: 'Install Depencencies'
+          command: ls -l
+    
 workflows:
   version: 2
   go_build:
     jobs:
       - go_build
-  vue_build:
+  support:
     jobs:
       - support_build
+      - support_deploy:
+          requires:
+            - support_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - frontend/support
+            - .
       
   support_deploy:
     working_directory: ~/teixy
@@ -97,9 +97,8 @@ jobs:
       - run:
           name: 'Install Depencencies'
           command: |
-                ls -l
-                cd frontend
-                ls -l
+                cd frontend/support
+                npm install -save firebase-tools
     
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ jobs:
           command: |
                 cd frontend/support
                 npm install firebase-tools
+                firebase deploy --only hosting --project ${FIREBASE_PROJECT} --token ${FIREBASE_TOKEN}
     
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   go_build:
-    working_directory: ~/go/src/github.com/teixy/
+    working_directory: ~/go/src/github.com/teixy
 
     docker:
       - image: circleci/golang:1.12
@@ -33,7 +33,7 @@ jobs:
               go build -v -o main main.go
               
   support_build:
-    working_directory: ~/teixy/frontend/support/
+    working_directory: ~/teixy
     
     docker:
       - image: circleci/node:10.15.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,8 @@ jobs:
           name: Install latest yarn
           command: |
               cd frontend/support
-              npm uninstall yarn -g
-              npm install yarn -g
+              npm uninstall yarn
+              npm install yarn
               
       - run:
           name: Install node modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
               go build -v -o main main.go
               
   support_build:
-    working_directory: ~/teixy
+    working_directory: ~/teixy/frontend/support/
     
     docker:
       - image: circleci/node:10.15.0
@@ -52,7 +52,8 @@ jobs:
       - run:
           name: Install latest yarn
           command: |
-              npm uninstall yarn
+              ls
+              npm uninstall yarn -g
               npm install yarn -g
               
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
           name: yarn build
           command: |
                 cd frontend/support
+                ls
                 yarn run build
       
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
           name: 'Install Depencencies'
           command: |
                 cd frontend/support
-                npm install -save firebase-tools
+                npm install firebase-tools
     
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           name: Install latest yarn
           command: |
               npm uninstall yarn
-              npm install yarn
+              npm install yarn -g
               
       - run:
           name: Install node modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
           name: Install node modules
           command: |
                 cd frontend/support
+                ls
                 yarn install
               
       - save_cache:


### PR DESCRIPTION
# [20190305] firebaseにはciからdeployするように変更

## 概要
- ci configにdeploy用の設定を追加
- docker-composeからfirebase用のコンテナを削除（deployにしか使わないから）

本当はローカルでもできるんだけど
workflowを使うとlocal executeでエラーがでる（現状まだ対応していない？）
なので、このブランチをテスト用にする

## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



