### PR TITLE
[20190310] firebase stg deployするときにapproveが必要にする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,10 +135,14 @@ workflows:
   support:
     jobs:
       - support_build
+      - approve_deploy_stg:
+          type: approval
+          requires:
+            - support_build
       - support_deploy_stg:
           context: firebase
           requires:
-            - support_build
+            - approve_deploy_stg
           filters:
             branches:
               only: develop


### PR DESCRIPTION
# [20190310] firebase stg deployするときにapproveが必要にする

## 概要
- stg deploy job の前にapproveを噛ませる


## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



